### PR TITLE
Support refreshing expired Openplanet tokens

### DIFF
--- a/backend/api/auth.php
+++ b/backend/api/auth.php
@@ -55,11 +55,16 @@ if (stripos($contentType, 'application/json') !== false) {
 $token         = $data['token'] ?? null;
 $playerId      = $data['player_id'] ?? null;
 $pluginVersion = $data['plugin_version'] ?? null;
+$refreshToken  = $data['refresh_token'] ?? null;
 
 
 $token = isset($token) ? trim((string)$token) : null;
 if ($token && str_starts_with($token, 'Bearer ')) {
     $token = substr($token, 7); // "Bearer " removed
+}
+$refreshToken = isset($refreshToken) ? trim((string)$refreshToken) : null;
+if ($refreshToken === '') {
+    $refreshToken = null;
 }
 
 if (!$token || !$playerId) {
@@ -68,7 +73,75 @@ if (!$token || !$playerId) {
     exit;
 }
 
+/**
+ * @return array{0: array, 1: bool} Decoded response data and whether an HTTP error occurred
+ */
+function callOpenplanetEndpoint(string $url, array $payload, int $timeout = 5): array
+{
+    $payloadJson = json_encode($payload, JSON_UNESCAPED_SLASHES);
+    $options = [
+        'http' => [
+            'method'  => 'POST',
+            'header'  =>
+                "Content-Type: application/json\r\n" .
+                "User-Agent: PHP/" . phpversion() . " RMC_API/1.0 (Greep & FlinkTM)\r\n",
+            'content' => $payloadJson,
+            'timeout' => $timeout,
+            'ignore_errors' => true,
+        ],
+    ];
+
+    $context = stream_context_create($options);
+    $response = @file_get_contents($url, false, $context);
+    if ($response === false) {
+        return [[], true];
+    }
+
+    $decoded = json_decode($response, true);
+    if (!is_array($decoded)) {
+        $decoded = [];
+    }
+
+    return [$decoded, false];
+}
+
+function isExpiredTokenResponse(array $response): bool
+{
+    $error = $response['error'] ?? null;
+    if (is_string($error)) {
+        $normalizedError = strtolower($error);
+        if (in_array($normalizedError, ['token_expired', 'expired_token', 'invalid_grant'], true)) {
+            return true;
+        }
+    }
+
+    $fragments = [];
+    foreach (['error_description', 'message', 'reason', 'detail'] as $key) {
+        if (isset($response[$key]) && is_string($response[$key])) {
+            $fragments[] = strtolower($response[$key]);
+        }
+    }
+
+    if (isset($response['errors']) && is_array($response['errors'])) {
+        foreach ($response['errors'] as $errValue) {
+            if (is_string($errValue)) {
+                $fragments[] = strtolower($errValue);
+            } elseif (is_array($errValue)) {
+                $fragments[] = strtolower(json_encode($errValue));
+            }
+        }
+    }
+
+    $combined = implode(' ', $fragments);
+    return $combined !== '' && str_contains($combined, 'expired');
+}
+
 // Auth with Openplanet
+$tokenForStorage      = $token;
+$latestRefreshToken   = $refreshToken;
+$openplanetData       = [];
+$expiredWithoutRefresh = false;
+
 if ($token === $openplanetSecret) {
     // Test token path
     $options = [
@@ -86,34 +159,83 @@ if ($token === $openplanetSecret) {
         'display_name' => $tmioData['displayname'] ?? "Unknown"
     ];
 } else {
-    // Verify token via Openplanet (JSON instead of x-www-form-urlencoded)
-    $openplanetUrl = "https://openplanet.dev/api/auth/validate";
-    $payload = json_encode([
-        'token'  => $token,            // no "Bearer "
+    $openplanetValidateUrl = "https://openplanet.dev/api/auth/validate";
+    [$openplanetData, $httpError] = callOpenplanetEndpoint($openplanetValidateUrl, [
+        'token'  => $token,
         'secret' => $openplanetSecret,
-    ], JSON_UNESCAPED_SLASHES);
+    ]);
 
-    $options = [
-        'http' => [
-            'method'  => 'POST',
-            'header'  =>
-                "Content-Type: application/json\r\n" .
-                "User-Agent: PHP/".phpversion()." RMC_API/1.0 (Greep & FlinkTM)\r\n",
-            'content' => $payload,
-            'timeout' => 5,
-            'ignore_errors' => true,
-        ]
-    ];
-
-    $context = stream_context_create($options);
-    $openplanetResponse = @file_get_contents($openplanetUrl, false, $context);
-    if ($openplanetResponse === false) {
+    if ($httpError) {
         http_response_code(502);
         echo json_encode(["success" => false, "message" => "Openplanet request failed"]);
         $conn->close();
         exit;
     }
-    $openplanetData = json_decode($openplanetResponse, true) ?: [];
+
+    $tokenExpired = isExpiredTokenResponse($openplanetData);
+
+    if ((!isset($openplanetData['account_id']) || $openplanetData['account_id'] !== $playerId)
+        && $refreshToken
+        && $tokenExpired
+    ) {
+        $refreshUrl = "https://openplanet.dev/api/auth/token";
+        [$refreshData, $refreshHttpError] = callOpenplanetEndpoint($refreshUrl, [
+            'secret'        => $openplanetSecret,
+            'refresh_token' => $refreshToken,
+        ]);
+
+        if ($refreshHttpError) {
+            http_response_code(502);
+            echo json_encode(["success" => false, "message" => "Openplanet refresh request failed"]);
+            $conn->close();
+            exit;
+        }
+
+        $newToken = null;
+        if (isset($refreshData['token']) && is_string($refreshData['token'])) {
+            $newToken = trim($refreshData['token']);
+        } elseif (isset($refreshData['access_token']) && is_string($refreshData['access_token'])) {
+            $newToken = trim($refreshData['access_token']);
+        }
+
+        if ($newToken) {
+            $token = $newToken;
+            $tokenForStorage = $newToken;
+            if (isset($refreshData['refresh_token']) && is_string($refreshData['refresh_token'])) {
+                $latestRefreshToken = trim($refreshData['refresh_token']) ?: $latestRefreshToken;
+            }
+
+            if (isset($refreshData['account_id'])) {
+                $openplanetData = $refreshData;
+            } else {
+                [$openplanetData, $httpError] = callOpenplanetEndpoint($openplanetValidateUrl, [
+                    'token'  => $token,
+                    'secret' => $openplanetSecret,
+                ]);
+
+                if ($httpError) {
+                    http_response_code(502);
+                    echo json_encode(["success" => false, "message" => "Openplanet request failed"]);
+                    $conn->close();
+                    exit;
+                }
+            }
+        } else {
+            http_response_code(401);
+            $errorMessage = "Authentication failed: token expired and refresh was rejected";
+            if (isset($refreshData['error']) && is_string($refreshData['error'])) {
+                $errorMessage .= " (" . $refreshData['error'] . ")";
+            }
+            if (isset($refreshData['error_description']) && is_string($refreshData['error_description'])) {
+                $errorMessage .= ": " . $refreshData['error_description'];
+            }
+            echo json_encode(["success" => false, "message" => $errorMessage]);
+            $conn->close();
+            exit;
+        }
+    } elseif ((!isset($openplanetData['account_id']) || $openplanetData['account_id'] !== $playerId) && $tokenExpired && !$refreshToken) {
+        $expiredWithoutRefresh = true;
+    }
 }
 
 // Check Auth Result
@@ -137,7 +259,7 @@ if (isset($openplanetData['account_id']) && $openplanetData['account_id'] === $p
         $sql = "INSERT INTO `players` (`accountId`, `displayName`, `lastLogon`, `lastPluginVersion`, `lastToken`)
                 VALUES (?, ?, NOW(), ?, ?)";
         if ($stmt = $conn->prepare($sql)) {
-            $stmt->bind_param("ssss", $openplanetData['account_id'], $openplanetData['display_name'], $pluginVersion, $token);
+            $stmt->bind_param("ssss", $openplanetData['account_id'], $openplanetData['display_name'], $pluginVersion, $tokenForStorage);
             $stmt->execute();
             $stmt->close();
         } else {
@@ -151,7 +273,7 @@ if (isset($openplanetData['account_id']) && $openplanetData['account_id'] === $p
                 SET `displayName` = ?, `lastLogon` = NOW(), `lastPluginVersion` = ?, `lastToken` = ?
                 WHERE `accountId` = ?";
         if ($stmt = $conn->prepare($sql)) {
-            $stmt->bind_param("ssss", $openplanetData['display_name'], $pluginVersion, $token, $openplanetData['account_id']);
+            $stmt->bind_param("ssss", $openplanetData['display_name'], $pluginVersion, $tokenForStorage, $openplanetData['account_id']);
             $stmt->execute();
             $stmt->close();
         } else {
@@ -165,13 +287,22 @@ if (isset($openplanetData['account_id']) && $openplanetData['account_id'] === $p
     echo json_encode([
         "success"      => true,
         "message"      => "Authenticated successfully",
-        "player_name"  => $openplanetData['display_name']
+        "player_name"  => $openplanetData['display_name'],
+        "token"        => $tokenForStorage,
+        "refresh_token" => $latestRefreshToken
     ]);
 } else {
     http_response_code(401);
     $errMsg = "Authentication failed";
-    if (isset($openplanetData["error"])) {
+    if ($expiredWithoutRefresh) {
+        $errMsg .= ": token expired and no refresh token was provided";
+    } elseif (isset($openplanetData["error"])) {
         $errMsg .= ": ".$openplanetData["error"];
+        if (isset($openplanetData['error_description'])) {
+            $errMsg .= " - ".$openplanetData['error_description'];
+        }
+    } elseif (isset($openplanetData['error_description'])) {
+        $errMsg .= ": ".$openplanetData['error_description'];
     }
     echo json_encode(["success" => false, "message" => $errMsg]);
     $conn->close();


### PR DESCRIPTION
## Summary
- accept optional refresh token input and add helpers to call Openplanet validate/refresh endpoints
- retry authentication with refreshed tokens when the validate API reports expiration and surface descriptive errors when refresh fails
- persist refreshed tokens in the database updates and include them in the API response payload so plugins can store them

## Testing
- php -l backend/api/auth.php
